### PR TITLE
Add `check_count!` and a thread-local feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,12 @@ documentation = "https://docs.rs/cov-mark"
 
 keywords = ["coverage", "test"]
 categories = ["development-tools"]
+
+[features]
+# Thread-local support enables more precise hit marks (no more false positives) and also allows for
+# an exact number of hits to be checked for (the `check_exact!` macro).
+thread-local = []
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "nightly_docs"]

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -11,3 +11,18 @@ fn test_safe_divide_by_zero() {
     cov_mark::check!(save_divide_zero);
     assert_eq!(safe_divide(92, 0), 0);
 }
+
+struct CoveredDropper;
+impl Drop for CoveredDropper {
+    fn drop(&mut self) {
+        cov_mark::hit!(covered_dropper_drops);
+    }
+}
+
+#[test]
+#[cfg(feature="thread-local")]
+fn test_drop_count() {
+    cov_mark::check_count!(covered_dropper_drops, 2);
+    let _covered_dropper1 = CoveredDropper;
+    let _covered_dropper2 = CoveredDropper;
+}


### PR DESCRIPTION
When the thread-local feature is enabled (which is infeasible on some
targets that do not support TLS) we can count the coverage hits without
the concern of false positives that is present when a single atomic
global is used.

This allows us to also expose an API that allows users to assert an
exact number of mark hits, useful when counting e.g. double drops.

Fixes #3 