### PR TITLE
CI the documentation

### DIFF
--- a/.github/ci.rs
+++ b/.github/ci.rs
@@ -29,6 +29,14 @@ fn try_main() -> Result<()> {
         shell("cargo test --all-features")?;
     }
 
+    {
+        let _s = Section::new("DOCS");
+        shell("rustup toolchain add nightly")?;
+        std::env::set_var("RUSTDOCFLAGS", "--cfg nightly_docs");
+        shell("cargo +nightly doc")?;
+        std::env::remove_var("RUSTDOCFLAGS");
+    }
+
     let current_branch = shell_output("git branch --show-current")?;
     if &current_branch == "master" {
         let _s = Section::new("PUBLISH");


### PR DESCRIPTION
I find myself commonly making a mistake of publishing releases with
broken docs (e.g. with broken links).

We verify that there are no broken links with

    cfg_attr(nightly_docs, deny(broken_intra_doc_links))

and now we verify that the documentation does in fact build through CI!