### PR TITLE
Introduce mark survey

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,6 +69,10 @@
 //! the mark was incremented.
 //! Each counter is stored as a thread-local, allowing for accurate per-thread
 //! counting.
+//!
+//! # Porting existing tests to cov-mark
+//!
+//! When incrementally outfitting a set of tests with markers, [`survey!`] may be useful.
 
 #![deny(rustdoc::broken_intra_doc_links)]
 #![allow(clippy::test_attr_in_doctest)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -284,7 +284,16 @@ pub mod __rt {
 
     impl Drop for SurveyGuard {
         fn drop(&mut self) {
-            SURVEY_RESPONSE.with(|it| it.borrow_mut().clear());
+            SURVEY_RESPONSE.with(|it| {
+                let mut it = it.borrow_mut();
+                for g in it.iter() {
+                    let hit_count = g.hits;
+                    if hit_count > 0 {
+                        eprintln!("mark {} ... hit {} times", g.mark, hit_count);
+                    }
+                }
+                it.clear();
+            });
             SURVEY.store(false, Relaxed);
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -320,6 +320,10 @@ pub mod __rt {
 
     impl Drop for SurveyGuard {
         fn drop(&mut self) {
+            if std::thread::panicking() {
+                return;
+            }
+
             SURVEY_RESPONSE.with(|it| {
                 let mut it = it.borrow_mut();
                 for g in it.iter() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -347,4 +347,13 @@ pub mod __rt {
             Guard
         }
     }
+
+    pub struct SurveyGuard;
+
+    impl SurveyGuard {
+        #[allow(clippy::new_without_default)]
+        pub fn new() -> SurveyGuard {
+            SurveyGuard
+        }
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -276,6 +276,7 @@ pub mod __rt {
     pub struct SurveyGuard;
 
     impl SurveyGuard {
+        #[allow(clippy::new_without_default)]
         pub fn new() -> SurveyGuard {
             SURVEY.store(true, Relaxed);
             SurveyGuard

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -239,17 +239,19 @@ pub mod __rt {
 
         #[cold]
         fn add_to_survey(mark: &'static str) {
-            let inner = GuardInner {
-                mark,
-                hits: 0,
-                expected_hits: None,
-            };
             SURVEY_RESPONSE.with(|it| {
                 let mut it = it.borrow_mut();
-                if it.iter().all(|g| g.mark != mark) {
-                    it.push(inner);
+                for survey in it.iter_mut() {
+                    if survey.mark == mark {
+                        survey.hits = survey.hits.saturating_add(1);
+                        return;
+                    }
                 }
-                it.iter_mut().for_each(|g| g.hit(mark));
+                it.push(GuardInner {
+                    mark,
+                    hits: 1,
+                    expected_hits: None,
+                });
             });
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -320,7 +320,9 @@ pub mod __rt {
                 let mut it = it.borrow_mut();
                 for g in it.iter() {
                     let hit_count = g.hits;
-                    if hit_count > 0 {
+                    if hit_count == 1 {
+                        eprintln!("mark {} ... hit once", g.mark);
+                    } else if 1 < hit_count {
                         eprintln!("mark {} ... hit {} times", g.mark, hit_count);
                     }
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,7 +72,7 @@
 //!
 //! # Porting existing tests to cov-mark
 //!
-//! When incrementally outfitting a set of tests with markers, [`survey!`] may be useful.
+//! When incrementally outfitting a set of tests with markers, [`survey`] may be useful.
 
 #![deny(rustdoc::broken_intra_doc_links)]
 #![allow(clippy::test_attr_in_doctest)]
@@ -170,7 +170,7 @@ macro_rules! check_count {
 ///
 /// #[test]
 /// fn drop_count_test() {
-///     cov_mark::survey!();
+///     let _survey = cov_mark::survey(); // sets a drop guard that tracks hits
 ///     let _covered_dropper1 = CoveredDropper;
 ///     let _covered_dropper2 = CoveredDropper;
 ///     safe_divide(92, 0);
@@ -179,11 +179,8 @@ macro_rules! check_count {
 ///     // "mark covered_dropper_drops ... hit 2 times"
 /// }
 /// ```
-#[macro_export]
-macro_rules! survey {
-    () => {
-        let _guard = $crate::__rt::SurveyGuard::new();
-    };
+pub fn survey() -> __rt::SurveyGuard {
+    __rt::SurveyGuard::new()
 }
 
 #[doc(hidden)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,6 +144,37 @@ macro_rules! check_count {
     };
 }
 
+/// Survey which marks are hit.
+///
+/// # Example
+///
+/// ```
+/// struct CoveredDropper;
+/// impl Drop for CoveredDropper {
+///     fn drop(&mut self) {
+///         cov_mark::hit!(covered_dropper_drops);
+///     }
+/// }
+///
+/// # fn safe_divide(dividend: u32, divisor: u32) -> u32 {
+/// #     if divisor == 0 {
+/// #         cov_mark::hit!(safe_divide_zero);
+/// #         return 0;
+/// #     }
+/// #     dividend / divisor
+/// # }
+///
+/// #[test]
+/// fn drop_count_test() {
+///     cov_mark::survey!();
+///     let _covered_dropper1 = CoveredDropper;
+///     let _covered_dropper2 = CoveredDropper;
+///     safe_divide(92, 0);
+///     // prints
+///     // "mark safe_divide_zero ... hit 1 times"
+///     // "mark covered_dropper_drops ... hit 2 times"
+/// }
+/// ```
 #[macro_export]
 macro_rules! survey {
     () => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -317,6 +317,8 @@ pub mod __rt {
 
     impl Drop for SurveyGuard {
         fn drop(&mut self) {
+            SURVEY.store(false, Relaxed);
+
             if std::thread::panicking() {
                 return;
             }
@@ -333,7 +335,6 @@ pub mod __rt {
                 }
                 it.clear();
             });
-            SURVEY.store(false, Relaxed);
         }
     }
 }

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -36,7 +36,7 @@ fn test_drop_count_fail() {
 
 #[test]
 fn test_mark_survey() {
-    cov_mark::survey!();
+    let _survey = cov_mark::survey();
     cov_mark::check_count!(covered_dropper_drops, 2);
     let _covered_dropper1 = CoveredDropper;
     let _covered_dropper2 = CoveredDropper;

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -33,3 +33,11 @@ fn test_drop_count_fail() {
     let _covered_dropper1 = CoveredDropper;
     let _covered_dropper2 = CoveredDropper;
 }
+
+#[test]
+fn test_mark_survey() {
+    cov_mark::survey!();
+    cov_mark::check_count!(covered_dropper_drops, 2);
+    let _covered_dropper1 = CoveredDropper;
+    let _covered_dropper2 = CoveredDropper;
+}


### PR DESCRIPTION
When initially designing a test, especially when retrofitting cov-mark
into an existing codebase, it can be quite handy to have a dryrun mode
during which we simply log which marks are hit.

This may help discover tests that cover similar marks, as well as help
select what other marks are sensible to add to the test.