### PR TITLE
Useful panic location

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -195,11 +195,6 @@ pub mod __rt {
 
     impl Guard {
         pub fn new(mark: &'static str, expected_hits: Option<usize>) -> Guard {
-            let inner = GuardInner {
-                mark,
-                hits: 0,
-                expected_hits,
-            };
             let f = |expected_hits, hit_count, mark| match expected_hits {
                 Some(hits) => assert!(
                     hit_count == hits,
@@ -208,7 +203,13 @@ pub mod __rt {
                 None => assert!(hit_count > 0, "mark {mark} was not hit"),
             };
             LEVEL.fetch_add(1, Relaxed);
-            ACTIVE.with(|it| it.borrow_mut().push(inner));
+            ACTIVE.with(|it| {
+                it.borrow_mut().push(GuardInner {
+                    mark,
+                    hits: 0,
+                    expected_hits,
+                })
+            });
             Guard { mark, f }
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -222,12 +222,12 @@ pub mod __rt {
             match last.expected_hits {
                 Some(hits) => assert!(
                     hit_count == hits,
-                    "{} mark was hit {} times, expected {}",
+                    "mark {} was hit {} times, expected {}",
                     self.inner.mark,
                     hit_count,
                     hits
                 ),
-                None => assert!(hit_count > 0, "{} mark was not hit", self.inner.mark),
+                None => assert!(hit_count > 0, "mark {} was not hit", self.inner.mark),
             }
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -213,6 +213,8 @@ pub mod __rt {
     }
 
     impl Guard {
+        // macro expansion inserts a [`AssertCallback`] defined in user code, so the panic location
+        // points to user code instead of cov-mark internals
         pub fn new(mark: &'static str, expected_hits: Option<usize>, f: AssertCallback) -> Guard {
             LEVEL.fetch_add(1, Relaxed);
             ACTIVE.with(|it| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,7 +80,7 @@
 /// ```
 /// fn safe_divide(dividend: u32, divisor: u32) -> u32 {
 ///     if divisor == 0 {
-///         cov_mark::hit!(save_divide_zero);
+///         cov_mark::hit!(safe_divide_zero);
 ///         return 0;
 ///     }
 ///     dividend / divisor
@@ -100,12 +100,12 @@ macro_rules! hit {
 /// ```
 /// #[test]
 /// fn test_safe_divide_by_zero() {
-///     cov_mark::check!(save_divide_zero);
+///     cov_mark::check!(safe_divide_zero);
 ///     assert_eq!(safe_divide(92, 0), 0);
 /// }
 /// # fn safe_divide(dividend: u32, divisor: u32) -> u32 {
 /// #     if divisor == 0 {
-/// #         cov_mark::hit!(save_divide_zero);
+/// #         cov_mark::hit!(safe_divide_zero);
 /// #         return 0;
 /// #     }
 /// #     dividend / divisor

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -159,7 +159,7 @@ pub mod __rt {
     static LEVEL: AtomicUsize = AtomicUsize::new(0);
 
     thread_local! {
-        static ACTIVE: RefCell<Vec<GuardInner>> = Default::default();
+        static ACTIVE: RefCell<Vec<GuardInner>> = const { RefCell::new(Vec::new()) };
     }
 
     #[inline(always)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -154,7 +154,7 @@ pub mod __rt {
     };
 
     /// Even with
-    /// https://github.com/rust-lang/rust/commit/641d3b09f41b441f2c2618de32983ad3d13ea3f8,
+    /// <https://github.com/rust-lang/rust/commit/641d3b09f41b441f2c2618de32983ad3d13ea3f8>,
     /// a `thread_local` generates significantly more verbose assembly on x86
     /// than atomic, so we'll use atomic for the fast path
     static LEVEL: AtomicUsize = AtomicUsize::new(0);

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -27,7 +27,7 @@ fn test_drop_count() {
 }
 
 #[test]
-#[should_panic(expected = "covered_dropper_drops mark was hit 2 times, expected 1")]
+#[should_panic(expected = "mark covered_dropper_drops was hit 2 times, expected 1")]
 fn test_drop_count_fail() {
     cov_mark::check_count!(covered_dropper_drops, 1);
     let _covered_dropper1 = CoveredDropper;

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -1,6 +1,6 @@
 fn safe_divide(dividend: u32, divisor: u32) -> u32 {
     if divisor == 0 {
-        cov_mark::hit!(save_divide_zero);
+        cov_mark::hit!(safe_divide_zero);
         return 0;
     }
     dividend / divisor
@@ -8,7 +8,7 @@ fn safe_divide(dividend: u32, divisor: u32) -> u32 {
 
 #[test]
 fn test_safe_divide_by_zero() {
-    cov_mark::check!(save_divide_zero);
+    cov_mark::check!(safe_divide_zero);
     assert_eq!(safe_divide(92, 0), 0);
 }
 


### PR DESCRIPTION
Before this PR, the panic location pointed to a useless internal `cov-mark` function. By tweaking macro expansion, we can get the panic to point to the exact location the user would want:

Before
```
---- test_drop_count stdout ----

thread 'test_drop_count' panicked at src/lib.rs:285:31: // points to internals
mark covered_dropper_drops was hit 2 times, expected 1
```

After
```
---- test_drop_count stdout ----

thread 'test_drop_count' panicked at tests/smoke.rs:24:5: // points to exact line in failing test
mark covered_dropper_drops was hit 2 times, expected 1
```

Builds on #18 
